### PR TITLE
Add the option to set a Bitmap as ImageResource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ apks
 # Gradle
 build
 .gradle
+sample/signing.properties
+

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you use gradle to build your Android project you can simply add a dependency 
 
 dependencies {  
     mavenCentral()
-    compile 'com.github.manuelpeinado.imagelayout:imagelayout:+'
+    compile 'com.github.manuelpeinado.imagelayout:imagelayout:1.1.0'
 }
 
 ```

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -15,6 +15,14 @@ android {
         versionCode Integer.parseInt(project.VERSION_CODE)
     }
 
+    signingConfigs { release }
+
+    buildTypes {
+        release {
+            signingConfig signingConfigs.release
+        }
+    }
+
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'
@@ -28,3 +36,21 @@ android {
     }
 }
 
+
+File propFile = file('signing.properties');
+if (propFile.exists()) {
+    def Properties props = new Properties()
+    props.load(new FileInputStream(propFile))
+
+    if (props.containsKey('STORE_FILE') && props.containsKey('STORE_PASSWORD') &&
+            props.containsKey('KEY_ALIAS') && props.containsKey('KEY_PASSWORD')) {
+        android.signingConfigs.release.storeFile = file(props['STORE_FILE'])
+        android.signingConfigs.release.storePassword = props['STORE_PASSWORD']
+        android.signingConfigs.release.keyAlias = props['KEY_ALIAS']
+        android.signingConfigs.release.keyPassword = props['KEY_PASSWORD']
+    } else {
+        android.buildTypes.release.signingConfig = null
+    }
+} else {
+    android.buildTypes.release.signingConfig = null
+}


### PR DESCRIPTION
you have these methods..

```
    /**
     * Changes the background image and its layout dimensions.
     */
    public void setImageResource(int imageResource, int imageWidth, int imageHeight) {
        bitmap = extractBitmapFromDrawable(getResources().getDrawable(imageResource));
        bitmapSrcRect = bitmapRect(bitmap);

        this.imageWidth = imageWidth;
        this.imageHeight = imageHeight;

        rebuildFitter();
    }

    private static Bitmap extractBitmapFromDrawable(Drawable drawable) {
        return ((BitmapDrawable) drawable).getBitmap();
    }
```

But you have to pass the image as `int` from the resources, there's should be a way to set a Bitmap directly as ImageResource, i think it is possible and it is not a big deal, but i want to set it programmatically depending on the situation and it will be very helpful in my needs..

Great tool, by the way!! 
